### PR TITLE
Use existing modulemap and umbrella header

### DIFF
--- a/Sources/MMWormhole/include/MMWormholeUmbrella.h
+++ b/Sources/MMWormhole/include/MMWormholeUmbrella.h
@@ -1,0 +1,1 @@
+../../../MMWormhole/MMWormhole/MMWormholeUmbrella.h

--- a/Sources/MMWormhole/include/module.modulemap
+++ b/Sources/MMWormhole/include/module.modulemap
@@ -1,4 +1,1 @@
-module MMWormhole {
-    umbrella "."
-    export *
-}
+../../../MMWormhole/MMWormhole/module.modulemap


### PR DESCRIPTION
Previous attempt led to compiler errors resembling "module.modulemap:2:5: umbrella for module 'MMWormhole' already covers this directory".