### PR TITLE
Copy umbrella header and modulemap instead of symlinking

### DIFF
--- a/Sources/MMWormhole/include/MMWormholeUmbrella.h
+++ b/Sources/MMWormhole/include/MMWormholeUmbrella.h
@@ -1,1 +1,28 @@
-../../../MMWormhole/MMWormhole/MMWormholeUmbrella.h
+//
+//  MMWormhole.h
+//  MMWormhole
+//
+//  Created by LEI on 5/11/15.
+//  Copyright (c) 2015 MMWormhole. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for MMWormhole.
+FOUNDATION_EXPORT double MMWormholeVersionNumber;
+
+//! Project version string for MMWormhole.
+FOUNDATION_EXPORT const unsigned char MMWormholeVersionString[];
+
+#import <MMWormhole/MMWormhole.h>
+#import <MMWormhole/MMWormholeFileTransiting.h>
+#import <MMWormhole/MMWormholeCoordinatedFileTransiting.h>
+
+#if ( ( defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 90000 ) || TARGET_OS_WATCH )
+#import <MMWormhole/MMWormholeSession.h>
+#import <MMWormhole/MMWormholeSessionContextTransiting.h>
+#import <MMWormhole/MMWormholeSessionFileTransiting.h>
+#import <MMWormhole/MMWormholeSessionMessageTransiting.h>
+#endif
+
+#import <MMWormhole/MMWormholeTransiting.h>

--- a/Sources/MMWormhole/include/module.modulemap
+++ b/Sources/MMWormhole/include/module.modulemap
@@ -1,1 +1,6 @@
-../../../MMWormhole/MMWormhole/module.modulemap
+framework module MMWormhole {
+  umbrella header "MMWormholeUmbrella.h"
+
+  export *
+  module * { export * }
+}


### PR DESCRIPTION
Symlinks don't work after Xcode checks out the package.